### PR TITLE
fix README.md,the `src` path is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pip install -r requirements.txt
 ```
 2. Go to the directory where app.py is located:
 ```bash
-cd src      
+cd src/ollama_ocr      
 ```
 3. Run the Streamlit app:
 ```bash


### PR DESCRIPTION
the `src` path is incorrect,`src\ollama_ocr` is the correct path, the `app.py` is in `src\ollama_ocr`